### PR TITLE
Add raw smartctl input parsing

### DIFF
--- a/src/disk_health_predictor/classifiers/_base.py
+++ b/src/disk_health_predictor/classifiers/_base.py
@@ -1,5 +1,6 @@
 """Abstract base class for all classifiers. Defines the API for classifiers."""
 from abc import abstractmethod
+from typing import Dict
 
 
 class DiskHealthClassifier:
@@ -13,6 +14,64 @@ class DiskHealthClassifier:
     @abstractmethod
     def initialize(self, model_dir: str) -> None:
         raise NotImplementedError()
+
+    @classmethod
+    def extract_ata_smart_attrs(cls, health_data: Dict) -> Dict:
+        """
+        Extract data from smartctl attribute table in from smartctl json.
+        """
+        # dummy vars to be used later. avoid overhead of created multiple empty objects
+        emptydict = {}
+        emptylist = []
+
+        # init empty dict for each date
+        flattened_smart_data = dict((d, dict()) for d in health_data.keys())
+
+        # parse data for each day and save it in the flattened data dict
+        for date, date_smart_json in health_data.items():
+            for attr in date_smart_json.get("ata_smart_attributes", emptydict).get(
+                "table", emptylist
+            ):
+                # smart stat number
+                attr_id = attr["id"]
+
+                # its better to extract raw value from string key instead of value key
+                # in some cases, raw value looks like this -
+                # {'value': 471138330, 'string': '26 (Min/Max 21/28)'}
+                # here, the correct value should be 26 and not 471138330
+                raw_str = attr.get("raw", emptydict).get("string", None)
+                if raw_str is not None:
+                    raw_str = raw_str.split(" ", maxsplit=1)[0]
+
+                # try to parse value from string
+                if raw_str.isdigit():
+                    raw = int(raw_str)
+                else:
+                    # if not possible, use the number in "value" key
+                    # case in point - "string": "7019h+59m+24.383s"
+                    # TODO: also throw warning
+                    raw = attr.get("raw", emptydict).get("value")
+
+                # save raw and normalized values
+                flattened_smart_data[date][f"smart_{attr_id}_raw"] = raw
+                flattened_smart_data[date][f"smart_{attr_id}_normalized"] = attr.get(
+                    "value", None
+                )
+
+            # try to add power on hours manually
+            # in case it wasnt extracted from smart attribute table
+            if flattened_smart_data[date].get("smart_9_raw") is None:
+                flattened_smart_data[date]["smart_9_raw"] = date_smart_json.get(
+                    "power_on_time", emptydict
+                ).get("hours")
+
+            # add device capacity
+            user_capacity = date_smart_json.get("user_capacity", emptydict).get("bytes")
+            if isinstance(user_capacity, dict):
+                user_capacity = user_capacity["n"]
+            flattened_smart_data[date]["user_capacity"] = user_capacity
+
+        return flattened_smart_data
 
     @abstractmethod
     def predict(self, dataset) -> str:

--- a/src/disk_health_predictor/classifiers/_redhat.py
+++ b/src/disk_health_predictor/classifiers/_redhat.py
@@ -22,13 +22,13 @@ class RHDiskHealthClassifier(DiskHealthClassifier):
     This class implements a disk failure prediction module.
     """
 
-    # json with manufacturer names as keys
+    # json with vendor names as keys
     # and features used for prediction as values
     CONFIG_FILE = "config.json"
     PREDICTION_CLASSES = {-1: "Unknown", 0: "Good", 1: "Warning", 2: "Bad"}
 
     # model name prefixes to identify vendor
-    MANUFACTURER_MODELNAME_PREFIXES = {
+    VENDOR_MODELNAME_PREFIXES = {
         "WDC": "WDC",
         "Toshiba": "Toshiba",  # for cases like "Toshiba xxx"
         "TOSHIBA": "Toshiba",  # for cases like "TOSHIBA xxx"
@@ -62,49 +62,54 @@ class RHDiskHealthClassifier(DiskHealthClassifier):
         with open(config_path) as f_conf:
             self.model_context = json.load(f_conf)
 
-        # ensure all manufacturers whose context is defined in config file
+        # ensure all vendors whose context is defined in config file
         # have models and scalers saved inside model_dirpath
-        for manufacturer in self.model_context:
-            scaler_path = os.path.join(model_dirpath, manufacturer + "_scaler.pkl")
+        for vendor in self.model_context:
+            scaler_path = os.path.join(model_dirpath, vendor + "_scaler.pkl")
             if not os.path.isfile(scaler_path):
                 raise Exception(f"Missing scaler file: {scaler_path}")
-            model_path = os.path.join(model_dirpath, manufacturer + "_predictor.pkl")
+            model_path = os.path.join(model_dirpath, vendor + "_predictor.pkl")
             if not os.path.isfile(model_path):
                 raise Exception(f"Missing model file: {model_path}")
 
         self.model_dirpath = model_dirpath
 
     def __preprocess(
-        self, disk_days: Sequence[DevSmartT], manufacturer: str
+        self, disk_days: Sequence[DevSmartT], vendor: str
     ) -> Optional[np.ndarray]:
         """Scales and transforms input dataframe to feed it to prediction model
         Arguments:
-            disk_days {list} -- list in which each element is a dictionary with key,val
-                                as feature name,value respectively.
-                                e.g.[{'smart_1_raw': 0, 'user_capacity': 512 ...}, ...]
-            manufacturer {str} -- manufacturer of the hard drive
+            disk_days {dict} -- dict where key is date, value is smartctl data extracted
+                                from that date e.g. {"2020-01-31 12:12:01": {"wwn":
+                                {"naa": 5, "oui": 3152}, "ata_smart_attributes":
+                                {"table": [{"id": 1, "raw": {"value": 60404968, ... }
+            vendor {str} -- vendor of the hard disk
         Returns:
             numpy.ndarray -- (n, d) shaped array of n days worth of data and d
                                 features, scaled
         """
-        # get the attributes that were used to train model for current manufacturer
+        # get the attributes that were used to train model for current vendor
         try:
-            model_smart_attr = self.model_context[manufacturer]
+            model_smart_attr = self.model_context[vendor]
         except KeyError:
             RHDiskHealthClassifier.LOGGER.debug(
                 "No context (SMART attributes on which model has been trained) found \
-                    for manufacturer: {}".format(
-                    manufacturer
+                    for vendor: {}".format(
+                    vendor
                 )
             )
             return None
+
+        # flattened dict {"smart_1_raw": 1, "user_capacity": 1000, "smart_9_norm": 12}
+        disk_days_smartctl_attrs = self.extract_ata_smart_attrs(disk_days)
 
         # convert to structured array, keeping only the required features
         # assumes all data is in float64 dtype
         try:
             struc_dtypes = [(attr, np.float64) for attr in model_smart_attr]
             values = [
-                tuple(day[attr] for attr in model_smart_attr) for day in disk_days
+                tuple(daydata[attr] for attr in model_smart_attr)
+                for _, daydata in disk_days_smartctl_attrs.items()
             ]
             disk_days_sa = np.array(values, dtype=struc_dtypes)
         except KeyError:
@@ -157,62 +162,118 @@ class RHDiskHealthClassifier(DiskHealthClassifier):
         )
 
         # scale features
-        scaler_path = os.path.join(self.model_dirpath, manufacturer + "_scaler.pkl")
+        scaler_path = os.path.join(self.model_dirpath, vendor + "_scaler.pkl")
         with open(scaler_path, "rb") as f:
             scaler = pickle.load(f)
         featurized = scaler.transform(featurized)
         return featurized
 
     @staticmethod
-    def __get_manufacturer(model_name: str) -> Optional[str]:
-        """Returns the manufacturer name for a given hard drive model name
+    def _estimate_vendor_from_modelname(model_name: str) -> Optional[str]:
+        """Returns the vendor name for a given hard disk model name
         Arguments:
-            model_name {str} -- hard drive model name
+            model_name {str} -- hard disk model name
         Returns:
-            str -- manufacturer name
+            str -- vendor name
         """
         for (
             prefix,
-            manufacturer,
-        ) in RHDiskHealthClassifier.MANUFACTURER_MODELNAME_PREFIXES.items():
+            vendor,
+        ) in RHDiskHealthClassifier.VENDOR_MODELNAME_PREFIXES.items():
             if model_name.startswith(prefix):
-                return manufacturer.lower()
+                return vendor.lower()
         # print error message
         RHDiskHealthClassifier.LOGGER.debug(
-            f"Could not infer manufacturer from model name {model_name}"
+            f"Could not infer vendor from model name {model_name}"
         )
         return None
 
-    def predict(self, disk_days: Sequence[DevSmartT]) -> str:
-        # get manufacturer preferably as a smartctl attribute
-        # if not available then infer using model name
-        manufacturer = disk_days[0].get("vendor")
-        if manufacturer is None:
+    @staticmethod
+    def _extract_vendor_from_smartctl(disk_days: dict) -> Optional[str]:
+        """Returns the vendor name for the hard disk given smartctl data
+        Arguments:
+            disk_days {dict} -- dictionary of smartctl data. each key is
+            a day, value is smartctl data collected by ceph
+        Returns:
+            str -- vendor name
+        """
+        # get vendor preferably as a smartctl attribute
+        # check if the "vendor" key exists in data collected from any day
+        vendor_key_found = any(
+            "vendor" in daydata.keys() for _, daydata in disk_days.items()
+        )
+
+        if vendor_key_found:
+            # sanity check
+            # there should only be one unique value for vendor for all days
+            extracted_vendors = set(
+                [daydata["vendor"] for _, daydata in disk_days.items()]
+            )
+            if len(extracted_vendors) > 1:
+                RHDiskHealthClassifier.LOGGER.warning(
+                    f'Multiple values found for "vendor": {extracted_vendors}. \
+                        Will randomly pick one of these.'
+                )
+
+            vendor = list(extracted_vendors)[0]
+
+        # if not available as smartctl attr then infer using model name
+        else:
             RHDiskHealthClassifier.LOGGER.debug(
                 '"vendor" field not found in smartctl output. Will try to infer \
-                    manufacturer from model name.'
-            )
-            manufacturer = RHDiskHealthClassifier.__get_manufacturer(
-                disk_days[0].get("model_name", "")
+                    vendor from model name.'
             )
 
+            # check if the "model_name" key exists in data collected from any day
+            modelname_key_found = any(
+                "model_name" in daydata.keys() for _, daydata in disk_days.items()
+            )
+            if modelname_key_found:
+                # sanity check
+                # there should only be one unique value for vendor for all days
+                extracted_modelnames = set(
+                    [daydata["model_name"] for _, daydata in disk_days.items()]
+                )
+                if len(extracted_modelnames) > 1:
+                    RHDiskHealthClassifier.LOGGER.warning(
+                        f'Multiple values found for "model_name": {extracted_modelnames}. \
+                            Will randomly pick one of these.'
+                    )
+
+                model_name = list(extracted_modelnames)[0]
+                vendor = RHDiskHealthClassifier._estimate_vendor_from_modelname(
+                    model_name
+                )
+            else:
+                # if model name was also not found, there is no other way to get vendor
+                RHDiskHealthClassifier.LOGGER.warning(
+                    "Model name not found in smartctl data."
+                )
+                vendor = None
+
+        return vendor
+
+    def predict(self, disk_days: Sequence[DevSmartT]) -> str:
+        # get vendor
+        vendor = RHDiskHealthClassifier._extract_vendor_from_smartctl(disk_days)
+
         # print error message, return Unknown, and continue execution
-        if manufacturer is None:
+        if vendor is None:
             RHDiskHealthClassifier.LOGGER.debug(
-                "Manufacturer could not be determiend. This may be because \
-                DiskPredictor has never encountered this manufacturer before, \
-                    or the model name is not according to the manufacturer's \
+                "vendor could not be determiend. This may be because \
+                DiskPredictor has never encountered this vendor before, \
+                    or the model name is not according to the vendor's \
                         naming conventions known to DiskPredictor"
             )
             return RHDiskHealthClassifier.PREDICTION_CLASSES[-1]
 
         # preprocess for feeding to model
-        preprocessed_data = self.__preprocess(disk_days, manufacturer)
+        preprocessed_data = self.__preprocess(disk_days, vendor)
         if preprocessed_data is None:
             return RHDiskHealthClassifier.PREDICTION_CLASSES[-1]
 
-        # get model for current manufacturer
-        model_path = os.path.join(self.model_dirpath, manufacturer + "_predictor.pkl")
+        # get model for current vendor
+        model_path = os.path.join(self.model_dirpath, vendor + "_predictor.pkl")
         with open(model_path, "rb") as f:
             model = pickle.load(f)
 


### PR DESCRIPTION
Closes #10 

- Adds a helper function (as a class method) to extract smartctl attribute table as a well-defined dictionary, from the raw smartctl json input. This is the dictionary that will be passed to predict function.
- Updates vendor extraction process in `RHDiskHealthClassifier` to work with the raw input when trying to determine disk vendor.
- Minor naming convention change from `manufacturer` to `vendor`