### PR TITLE
Fix array shape mismatch in preprocessing

### DIFF
--- a/src/disk_health_predictor/classifiers/_redhat.py
+++ b/src/disk_health_predictor/classifiers/_redhat.py
@@ -127,7 +127,9 @@ class RHDiskHealthClassifier(DiskHealthClassifier):
 
         # view structured array as 2d array for applying rolling window transforms
         # NOTE: this is new behavior from numpy 1.15 to 1.16
-        disk_days_smartctl_attrs = structured_to_unstructured(disk_days_smartctl_attrs_sa)
+        disk_days_smartctl_attrs = structured_to_unstructured(
+            disk_days_smartctl_attrs_sa
+        )
 
         # featurize n (6 to 12) days data - mean,std,coefficient of variation
         # current model is trained on 6 days of data because that is what will be
@@ -136,23 +138,32 @@ class RHDiskHealthClassifier(DiskHealthClassifier):
         # rolling time window interval size in days
         roll_window_size = 6
 
-        # rolling means generator
+        # number of days of data available
         dataset_size = disk_days_smartctl_attrs.shape[0] - roll_window_size + 1
-        gen = (
-            disk_days_smartctl_attrs[i : i + roll_window_size, ...].mean(axis=0)
-            for i in range(dataset_size)
-        )
-        means = np.vstack(gen)
 
-        # rolling stds generator
-        gen = (
-            disk_days_smartctl_attrs[i : i + roll_window_size, ...].std(axis=0, ddof=1)
-            for i in range(dataset_size)
+        # rolling means
+        means = np.vstack(
+            [
+                disk_days_smartctl_attrs[i : i + roll_window_size, ...].mean(axis=0)
+                for i in range(dataset_size)
+            ]
         )
-        stds = np.vstack(gen)
+
+        # rolling stds
+        stds = np.vstack(
+            [
+                disk_days_smartctl_attrs[i : i + roll_window_size, ...].std(
+                    axis=0, ddof=1
+                )
+                for i in range(dataset_size)
+            ]
+        )
 
         # coefficient of variation
-        cvs = stds / means
+        # there might be cases where mean for a smart attribute is 0
+        # this is not necessarily something to warn about
+        with np.errstate(divide="ignore", invalid="ignore"):
+            cvs = stds / means
         cvs[np.isnan(cvs)] = 0
         featurized = np.hstack(
             (


### PR DESCRIPTION
Closes #14 

- Updates how structured array is converted to regular numpy ndarray
- Updates how rolling means and rolling standard deviations are stacked (use list instead of generator) to suppress warnings

Note: this PR is rebased on top of #13 so please make sure that PR is merged before this one :)